### PR TITLE
VCST-5163: Stable 15 — WebHooks (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.WebHooksModule.Core/VirtoCommerce.WebhooksModule.Core.csproj
+++ b/src/VirtoCommerce.WebHooksModule.Core/VirtoCommerce.WebhooksModule.Core.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.WebHooksModule.Data/VirtoCommerce.WebhooksModule.Data.csproj
+++ b/src/VirtoCommerce.WebHooksModule.Data/VirtoCommerce.WebhooksModule.Data.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WebHooksModule.Core\VirtoCommerce.WebhooksModule.Core.csproj" />

--- a/src/VirtoCommerce.WebHooksModule.Web/module.manifest
+++ b/src/VirtoCommerce.WebHooksModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1004.0</version>
   <version-tag />
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
   </dependencies>
 

--- a/src/VirtoCommerce.WebhooksModule.Data.MySql/VirtoCommerce.WebhooksModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.WebhooksModule.Data.MySql/VirtoCommerce.WebhooksModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WebHooksModule.Data\VirtoCommerce.WebhooksModule.Data.csproj" />

--- a/src/VirtoCommerce.WebhooksModule.Data.PostgreSql/VirtoCommerce.WebhooksModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.WebhooksModule.Data.PostgreSql/VirtoCommerce.WebhooksModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WebHooksModule.Data\VirtoCommerce.WebhooksModule.Data.csproj" />

--- a/src/VirtoCommerce.WebhooksModule.Data.SqlServer/VirtoCommerce.WebhooksModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.WebhooksModule.Data.SqlServer/VirtoCommerce.WebhooksModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.WebHooksModule.Data\VirtoCommerce.WebhooksModule.Data.csproj" />


### PR DESCRIPTION
Part of **Stable 15** (Wave 1). Builds against the published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) from nuget.org.

- Platform -> **3.1039.0**; module version -> **3.1004.0**.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and manifest version bumps only; no application logic or webhook behavior changes in this diff.
> 
> **Overview**
> Aligns the WebHooks module with **Stable 15** by raising all **VirtoCommerce.Platform** NuGet references from `3.1007.10` to **`3.1039.0`** across Core, Data (including Hangfire), and the MySql/PostgreSql/SqlServer data provider projects.
> 
> Updates **`module.manifest`** so **`platformVersion`** matches **`3.1039.0`**, ensuring the module declares compatibility with the published platform release used for this wave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb5e583c43c38514887bc9d219b41e6f6b622a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.WebHooks_3.1004.0-pr-87-bb5e.zip